### PR TITLE
fix failed actions detection

### DIFF
--- a/check_crm
+++ b/check_crm
@@ -175,7 +175,7 @@ sub check_set_stopped {
 
 sub check_failed_actions {
   my $line = shift;
-  if ( $line =~ m/^Failed actions\:/ ) {
+  if ( $line =~ m/^Failed [aA]ctions\:/ ) {
       $np->add_message( CRITICAL, "; failed actions detected or not cleaned up" );
   }
 }


### PR DESCRIPTION
I noticed that some versions of corosync shows the failed actions with capitals.
